### PR TITLE
Fixing a possible auto-correct error (recipes)

### DIFF
--- a/docs/integrations/automation.md
+++ b/docs/integrations/automation.md
@@ -16,15 +16,15 @@ If you add a lot of stuff to Raindrop.io or even if you’re just getting starte
 - [Send new bookmarks to Google Sheet](https://ifttt.com/applets/hn5RNTPp-log-new-items-in-raindrop-io-to-a-google-sheet)
 - [Save favorite Youtube videos](https://ifttt.com/applets/DJyFrvNd-save-liked-youtube-video-to-raindrop-io)
 - [Save favorite Tweets](https://ifttt.com/applets/zY5kqKtL-save-the-tweets-you-like-in-raindrop-io)
-- [**Check all reciepts**](https://ifttt.com/raindrop)
+- [**Check all recipes**](https://ifttt.com/raindrop)
 
 You can even [create your own integrations](https://ifttt.com/create)! Just select Raindrop.io from apps list.
 
 ## Zapier
 Zapier is very similar to IFTTT, but have a lot more functionality and flexibility.
-Usually it used in companies to automate they workflows. Grab one of the predifined reciepts below or create custom to improve your team productivity:
+Usually it used in companies to automate they workflows. Grab one of the predifined recipes below or create custom to improve your team productivity:
 
 - [Save favorite Github repositories](https://zapier.com/apps/github/integrations/raindropio/231017/create-new-global-events-in-github-as-raindropio-items)
 - [Save favorite Slack links](https://zapier.com/apps/raindropio/integrations/slack/110589/save-new-links-from-slack-messages-to-raindropio)
 - [Save RSS](https://zapier.com/apps/raindropio/integrations/rss/205642/save-new-rss-items-to-raindropio)
-- [**Check all reciepts**](https://zapier.com/apps/raindropio) or make your own
+- [**Check all recipes**](https://zapier.com/apps/raindropio) or make your own


### PR DESCRIPTION
The word 'recipes' was mentioned as 'receipts', possibly due to some kind of auto-correct in the publishing workflow.