### PR TITLE
Add Node-RED community integration details to automation documentation

### DIFF
--- a/docs/integrations/automation.md
+++ b/docs/integrations/automation.md
@@ -25,6 +25,11 @@ n8n has built-in support for a wide range of Raindrop features, including gettin
 
 [Learn more](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.raindrop/)
 
+## Node-RED
+For Node-RED users, there is a community-maintained project that provides nodes covering the whole Web API endpoints to interact with Raindrop.io.
+
+[Learn more](https://flows.nodered.org/node/@dotwee/node-red-raindrop)
+
 ## Make.com
 Connect Raindrop.io with any of your favorite apps in just a few clicks
 


### PR DESCRIPTION
This pull request adds a new section to the documentation for automation integrations, introducing Node-RED as a community-maintained option for interacting with Raindrop.io.

### Documentation updates:

* [`docs/integrations/automation.md`](diffhunk://#diff-4081a194e52560d43aee684499aaff3126d51d5d4386a9747eb203b8bc7b27e6R28-R32): Added a new section for Node-RED, highlighting community-maintained nodes for interacting with Raindrop.io's Web API, along with a link to the relevant Node-RED project.

### Links and References:

- https://github.com/dotWee/node-red-raindrop
- https://flows.nodered.org/node/@dotwee/node-red-raindrop

---

btw, thank you for building raindrop! just moved from Pocket and got a recommendation from HN, great work guys!